### PR TITLE
Completely reverts the UTC change

### DIFF
--- a/api.py
+++ b/api.py
@@ -48,7 +48,6 @@ def _ebgsDateTime(dateTimeString):
     Not exposed as all API calls should have code do all converstions
     '''
     dformat = '%Y-%m-%dT%H:%M:%S'
-    #return(datetime.strptime(dateTimeString[:len(dformat) + 2], dformat).replace(tzinfo=timezone.utc)) ## TypeError: can't compare offset-naive and offset-aware datetimes
     return(datetime.strptime(dateTimeString[:len(dformat) + 2], dformat))
 
 def _ebgsDateTimeString(dateTime):


### PR DESCRIPTION
Sorry, I didn't realize this was a problem.

I checked and the return value is used both to access remote systems and also to maintain local caches. I would have to review, and worse, touch a lot of code I don't know how to test.

Better to pretend this never happened. I can set the TZ only in the places I need it.
